### PR TITLE
Add parameters to API types

### DIFF
--- a/app/apis.go
+++ b/app/apis.go
@@ -1,9 +1,9 @@
 package app
 
 type HotelAPI interface {
-	ReserveRoom() (int, error)
+	ReserveRoom(adults, children int) (int, error)
 }
 
 type AirlineAPI interface {
-	ReserveFlight() (int, error)
+	ReserveFlight(seats int) (int, error)
 }

--- a/app/app.go
+++ b/app/app.go
@@ -19,19 +19,19 @@ func NewApp(hotel HotelAPI, airline AirlineAPI) *App {
 }
 
 // ReserveVacation reserves a vacation: Both a flight and a hotel room will be reserved.
-func (app *App) ReserveVacation() (*VacationReservation, error) {
+func (app *App) ReserveVacation(adults, children int) (*VacationReservation, error) {
 	reservation := new(VacationReservation)
 
 	errs := make([]error, 0, 2)
 
-	roomReservation, err := app.hotel.ReserveRoom()
+	roomReservation, err := app.hotel.ReserveRoom(adults, children)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("%w: %w", ErrReservationFailed, err))
 	}
 
 	reservation.RoomReservationID = roomReservation
 
-	flightReservation, err := app.airline.ReserveFlight()
+	flightReservation, err := app.airline.ReserveFlight(adults + children)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("%w: %w", ErrReservationFailed, err))
 	}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -16,14 +16,16 @@ func TestWithStubs(t *testing.T) {
 
 		application := app.NewApp(apis, apis)
 
-		apis.FnReserveFlight = func() (int, error) {
+		apis.FnReserveFlight = func(seats int) (int, error) {
 			return 1, nil
 		}
-		apis.FnReserveRoom = func() (int, error) {
+		apis.FnReserveRoom = func(adults, children int) (int, error) {
 			return 1, nil
 		}
 
-		reservation, err := application.ReserveVacation()
+		adults, children := 2, 3
+
+		reservation, err := application.ReserveVacation(adults, children)
 		require.NoError(t, err)
 		require.NotNil(t, reservation)
 
@@ -36,14 +38,16 @@ func TestWithStubs(t *testing.T) {
 
 		application := app.NewApp(apis, apis)
 
-		apis.FnReserveFlight = func() (int, error) {
+		apis.FnReserveFlight = func(seats int) (int, error) {
 			return 1, nil
 		}
-		apis.FnReserveRoom = func() (int, error) {
+		apis.FnReserveRoom = func(adults, children int) (int, error) {
 			return 0, errors.New("room unavailable")
 		}
 
-		reservation, err := application.ReserveVacation()
+		adults, children := 2, 3
+
+		reservation, err := application.ReserveVacation(adults, children)
 		require.Error(t, err)
 		require.NotNil(t, reservation)
 
@@ -56,14 +60,16 @@ func TestWithStubs(t *testing.T) {
 
 		application := app.NewApp(apis, apis)
 
-		apis.FnReserveFlight = func() (int, error) {
+		apis.FnReserveFlight = func(seats int) (int, error) {
 			return 0, errors.New("flight unavailable")
 		}
-		apis.FnReserveRoom = func() (int, error) {
+		apis.FnReserveRoom = func(adults, children int) (int, error) {
 			return 1, nil
 		}
 
-		reservation, err := application.ReserveVacation()
+		adults, children := 2, 3
+
+		reservation, err := application.ReserveVacation(adults, children)
 		require.Error(t, err)
 		require.NotNil(t, reservation)
 

--- a/app/test/stub.go
+++ b/app/test/stub.go
@@ -1,8 +1,8 @@
 package test
 
 type Stub struct {
-	FnReserveFlight func() (int, error)
-	FnReserveRoom   func() (int, error)
+	FnReserveFlight func(seats int) (int, error)
+	FnReserveRoom   func(adults, children int) (int, error)
 }
 
 func NewStub() *Stub {
@@ -10,17 +10,17 @@ func NewStub() *Stub {
 }
 
 // ReserveFlight implements Stub.
-func (s *Stub) ReserveFlight() (int, error) {
+func (s *Stub) ReserveFlight(seats int) (int, error) {
 	if s.FnReserveFlight != nil {
-		return s.FnReserveFlight()
+		return s.FnReserveFlight(seats)
 	}
 	panic(ErrNotImplemented)
 }
 
 // ReserveRoom implements Stub.
-func (s *Stub) ReserveRoom() (int, error) {
+func (s *Stub) ReserveRoom(adults, children int) (int, error) {
 	if s.FnReserveRoom != nil {
-		return s.FnReserveRoom()
+		return s.FnReserveRoom(adults, children)
 	}
 	panic(ErrNotImplemented)
 }


### PR DESCRIPTION
This PR adds parameters to API types. This is a preparation for #1 but does not yet add any spying.