### PR TITLE
Add spying on API parameters

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -17,9 +17,12 @@ func TestWithStubs(t *testing.T) {
 		application := app.NewApp(apis, apis)
 
 		apis.FnReserveFlight = func(seats int) (int, error) {
+			require.Equal(t, 5, seats)
 			return 1, nil
 		}
 		apis.FnReserveRoom = func(adults, children int) (int, error) {
+			require.Equal(t, 2, adults)
+			require.Equal(t, 3, children)
 			return 1, nil
 		}
 
@@ -39,9 +42,12 @@ func TestWithStubs(t *testing.T) {
 		application := app.NewApp(apis, apis)
 
 		apis.FnReserveFlight = func(seats int) (int, error) {
+			require.Equal(t, 5, seats)
 			return 1, nil
 		}
 		apis.FnReserveRoom = func(adults, children int) (int, error) {
+			require.Equal(t, 2, adults)
+			require.Equal(t, 3, children)
 			return 0, errors.New("room unavailable")
 		}
 
@@ -61,9 +67,12 @@ func TestWithStubs(t *testing.T) {
 		application := app.NewApp(apis, apis)
 
 		apis.FnReserveFlight = func(seats int) (int, error) {
+			require.Equal(t, 5, seats)
 			return 0, errors.New("flight unavailable")
 		}
 		apis.FnReserveRoom = func(adults, children int) (int, error) {
+			require.Equal(t, 2, adults)
+			require.Equal(t, 3, children)
 			return 1, nil
 		}
 


### PR DESCRIPTION
This PR adds #1

Currently no new types are added which is a bit unexpected. The way the stubs were implemented allowed
for simply using the stub including spying based on the assert library.

I am not yet sure if this is the approach I want to go for.